### PR TITLE
Fix `pages` check in articles parsing

### DIFF
--- a/references_parser/Parser.py
+++ b/references_parser/Parser.py
@@ -31,8 +31,10 @@ class Parser:
         if len(volume) != 0:
             result += SEP_DASH + volume
 
-        pages = bibtex_entry['pages'].split("--")
-        if len(pages) == 1:
+        pages = [] if 'pages' not in bibtex_entry else bibtex_entry['pages'].split("--")
+        if len(pages) == 0:
+            pass
+        elif len(pages) == 1:
             result += SEP_DASH + f"P. {pages[0]}"
         elif len(pages) == 2:
             result += SEP_DASH + f"P. {pages[0]}-{pages[1]}"


### PR DESCRIPTION
It turns out there are bibtex of articles without pages, so I've made the check similar to the one used in proceedings.

Example of an article bibtext without pages:
```
@article{bertasius2019learning,
  title={Learning temporal pose estimation from sparsely-labeled videos},
  author={Bertasius, Gedas and Feichtenhofer, Christoph and Tran, Du and Shi, Jianbo and Torresani, Lorenzo},
  journal={Advances in neural information processing systems},
  volume={32},
  year={2019}
}
```