### PR TITLE
bibtex_ssau: fixed first author chained initials & refactor

### DIFF
--- a/references_parser/cli.py
+++ b/references_parser/cli.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import click
 
 from .converters.url_converter import convert_urls_to_bibtex
@@ -10,7 +12,7 @@ PARSER_MAPPING = {
 }
 
 
-def log_errors(errors):
+def log_errors(errors: Dict[str, dict]):
     if errors is not None and len(errors.keys()) > 0:
         print("Some errors was occured during parsing:")
         for bibtex_title, error in errors.items():
@@ -68,7 +70,8 @@ def parse(path: str, save: str, parser: str, verbose: bool, beautify: int):
 
     result, errors = parser(citations)
 
-    end = "".join(["\n" for _ in range(beautify)])
+    # end = "".join(["\n" for _ in range(beautify)])
+    end = "\n" * beautify
 
     if verbose:
         for entry in result:

--- a/references_parser/models/bibtex_ssau.py
+++ b/references_parser/models/bibtex_ssau.py
@@ -6,7 +6,9 @@ from .bibtex import Bibtex
 
 
 class BibtexSsau(Bibtex):
-    def get_parsed_authors(self, return_all=False, space_between_initials=False) -> Tuple[Optional[str], str]:
+    def get_parsed_authors(
+        self, return_all=False, space_between_initials=False
+    ) -> Tuple[Optional[str], str]:
         """
         Perform authors entry parsing using following rules:
         1. Авторов < 4
@@ -33,22 +35,38 @@ class BibtexSsau(Bibtex):
             return last_names_joiner.join(splitted_author["last"])
 
         def all_first_name_initials(splitted_author):
-            return initials_joiner.join([f"{first_name[0]}." for first_name in splitted_author["first"]])
+            return initials_joiner.join(
+                [f"{first_name[0]}." for first_name in splitted_author["first"]]
+            )
 
         def parse_single_author(str_author):
             splitted_author = p.customization.splitname(str_author)
-            return all_first_name_initials(splitted_author) + " " + merged_last_names(splitted_author)
+            return (
+                all_first_name_initials(splitted_author)
+                + " "
+                + merged_last_names(splitted_author)
+            )
 
         splitted_first_author = p.customization.splitname(author_string[0])
-        first_author = merged_last_names(splitted_first_author) + ", " + all_first_name_initials(splitted_first_author)
+        first_author = (
+            merged_last_names(splitted_first_author)
+            + ", "
+            + all_first_name_initials(splitted_first_author)
+        )
 
         if len(author_string) < 4 or return_all:
-            authors = authors_joiner.join([parse_single_author(str_author) for str_author in author_string])
+            authors = authors_joiner.join(
+                [parse_single_author(str_author) for str_author in author_string]
+            )
         elif len(author_string) == 4:
-            authors = authors_joiner.join([parse_single_author(str_author) for str_author in author_string])
+            authors = authors_joiner.join(
+                [parse_single_author(str_author) for str_author in author_string]
+            )
             first_author = None
         else:
-            authors = authors_joiner.join([parse_single_author(str_author) for str_author in author_string[:3]])
+            authors = authors_joiner.join(
+                [parse_single_author(str_author) for str_author in author_string[:3]]
+            )
             first_author = None
             authors = f"{authors} [и др.]"
         return first_author, authors

--- a/references_parser/parsers/ssau_parser.py
+++ b/references_parser/parsers/ssau_parser.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple, Dict
 
 import bibtexparser as p
 from duckpy import Client
@@ -143,7 +143,7 @@ class SsauParser:
             result += SEP_DASH + f"P. {pages[0]}-{pages[1]}"
         return result + "."
 
-    def __call__(self, bibtex: str) -> List[Optional[str]]:
+    def __call__(self, bibtex: str) -> Tuple[List[Optional[str]], Dict[str, dict]]:
         if bibtex.endswith(".txt"):
             with open(bibtex, "r") as f:
                 bibtex_dict = p.load(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name='references_parser',
     packages=setuptools.find_packages(),
-    version='1.2.0',
+    version='1.2.1',
     description="Tool for parsing bibtex in ssau's format",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Addresses a situation when the first author has more than one first name. The current version chains the initials, e.g. "Brando, VE. ...". This fix solves the issue: "Brando, V.E. ..."

_fix(bibtex_ssau): fixed first author chained initials & refactor, fix(cli): minor changes, fix(ssau_parser): fix typing hinting_